### PR TITLE
消除 from 的警告

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ var _class = function () {
             var pluginOpts = setting.config || {};
 
             var _autoprefixer = postcss([ autoprefixer(pluginOpts) ]);
-            _autoprefixer.process(op.code).then(function (result) {
+            _autoprefixer.process(op.code, {from: undefined}).then(function (result) {
                 result.warnings().forEach(function (warn) {
                     console.warn(warn.toString());
                 });


### PR DESCRIPTION
直接使用的话，控制会出现警告字样：
Without `from` option PostCSS could generate wrong source map and will not find Browserslist config. Set it to CSS file path or to `undefined` to prevent this warning.
通过修改后可以去除该警告